### PR TITLE
Refactor to split FUUID into several type classes

### DIFF
--- a/core/shared/src/main/scala/org/pure4s/uuid4s/FUUID.scala
+++ b/core/shared/src/main/scala/org/pure4s/uuid4s/FUUID.scala
@@ -2,24 +2,17 @@ package org.pure4s.uuid4s
 
 import java.util.UUID
 import cats.effect.Sync
-import cats.implicits._
 
-/**
-  * Tagless final implementation of a FUUID.
-  */
-trait FUUID[F[_]] {
-  def fromString(value: String): F[UUID]
-  def toString(uuid: UUID): F[String]
-  def random: F[UUID]
-  def fromUUID(uuid: UUID): F[UUID]
-}
+trait FUUID[F[_]] extends FromUUID[F] with FromString[F] with ToString[F] with Random[F]
 
 object FUUID {
-  def apply[F[_]](implicit F: FUUID[F]): FUUID[F] = F
-  implicit def sync[F[_]: Sync]: FUUID[F] = new FUUID[F] {
-    override def fromString(value: String): F[UUID] = Sync[F].delay(UUID.fromString(value))
-    override def toString(uuid: UUID): F[String] = uuid.show.pure[F]
-    override def fromUUID(uuid: UUID): F[UUID] = Sync[F].pure(uuid)
-    override def random: F[UUID] = Sync[F].delay(UUID.randomUUID)
+
+  def apply[F[_]](implicit ev: FUUID[F]): FUUID[F] = ev
+
+  implicit def instance[F[_]: Sync] = new FUUID[F] {
+    def fromUUID(uuid: UUID): F[UUID] = FromUUID[F].fromUUID(uuid)
+    def fromString(value: String): F[UUID] = FromString[F].fromString(value)
+    def random: F[UUID] = Random[F].random
+    def toString(uuid: UUID): F[String] = ToString[F].toString(uuid)
   }
 }

--- a/core/shared/src/main/scala/org/pure4s/uuid4s/FromString.scala
+++ b/core/shared/src/main/scala/org/pure4s/uuid4s/FromString.scala
@@ -1,0 +1,18 @@
+package org.pure4s.uuid4s
+
+import java.util.UUID
+import cats.effect.Sync
+
+trait FromString[F[_]] {
+
+  def fromString(value: String): F[UUID]
+}
+
+object FromString {
+
+  def apply[F[_]](implicit ev: FromString[F]): FromString[F] = ev
+
+  implicit def instance[F[_]: Sync] = new FromString[F] {
+    override def fromString(value: String): F[UUID] = Sync[F].delay(UUID.fromString(value))
+  }
+}

--- a/core/shared/src/main/scala/org/pure4s/uuid4s/FromUUID.scala
+++ b/core/shared/src/main/scala/org/pure4s/uuid4s/FromUUID.scala
@@ -1,0 +1,18 @@
+package org.pure4s.uuid4s
+
+import java.util.UUID
+import cats.Applicative
+
+trait FromUUID[F[_]] {
+
+  def fromUUID(uuid: UUID): F[UUID]
+}
+
+object FromUUID {
+
+  def apply[F[_]](implicit ev: FromUUID[F]): FromUUID[F] = ev
+
+  implicit def instance[F[_]: Applicative] = new FromUUID[F] {
+    override def fromUUID(uuid: UUID): F[UUID] = Applicative[F].pure(uuid)
+  }
+}

--- a/core/shared/src/main/scala/org/pure4s/uuid4s/Random.scala
+++ b/core/shared/src/main/scala/org/pure4s/uuid4s/Random.scala
@@ -1,0 +1,18 @@
+package org.pure4s.uuid4s
+
+import java.util.UUID
+import cats.effect.Sync
+
+trait Random[F[_]] {
+
+  def random: F[UUID]
+}
+
+object Random {
+
+  def apply[F[_]](implicit ev: Random[F]): Random[F] = ev
+
+  implicit def instance[F[_]: Sync] = new Random[F] {
+    override def random: F[UUID] = Sync[F].delay(UUID.randomUUID)
+  }
+}

--- a/core/shared/src/main/scala/org/pure4s/uuid4s/ToString.scala
+++ b/core/shared/src/main/scala/org/pure4s/uuid4s/ToString.scala
@@ -1,0 +1,19 @@
+package org.pure4s.uuid4s
+
+import java.util.UUID
+import cats.Applicative
+import cats.implicits._
+
+trait ToString[F[_]] {
+
+  def toString(uuid: UUID): F[String]
+}
+
+object ToString {
+
+  def apply[F[_]](implicit ev: ToString[F]): ToString[F] = ev
+
+  implicit def instance[F[_]: Applicative] = new ToString[F] {
+    override def toString(uuid: UUID): F[String] = uuid.show.pure[F]
+  }
+}


### PR DESCRIPTION
The purpose is to be able to use an UUID operation (like `fromUUID` or `toString`) without being restricted to `Sync` type class when it is not necessary